### PR TITLE
fix: update download URL for Eclipse dash-licenses tool

### DIFF
--- a/actions/dash-licenses/action.yml
+++ b/actions/dash-licenses/action.yml
@@ -37,7 +37,8 @@ runs:
     - name: Download Eclipse dash-licenses tool
       run: |
         cd ${{ inputs.working-directory }}
-        wget -O dash-licenses-tool.jar 'https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST'
+        wget -O dash-licenses-tool.jar 'https://repo.eclipse.org/service/rest/v1/search/assets/download?repository=dash-maven2-releases&maven.groupId=org.eclipse.dash&maven.artifactId=org.eclipse.dash.licenses&maven.baseVersion=1.1.0&maven.extension=jar'
+
       shell: bash
 
     - name: Run Eclipse dash-licenses check


### PR DESCRIPTION
Replaced the outdated Maven redirect URL with the new repository-specific download URL targeting version 1.1.0.